### PR TITLE
Fix reposlug usage test

### DIFF
--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -10,7 +10,7 @@ stdout_e = hlp_e.stdout
 
 def test_usage():
     # tip: use cli(prog_name='committee') when calling the click.command function
-    assert stdout_m.startswith('Usage: committee [OPTIONS] REPOSLUGS...')
+    assert stdout_m.startswith('Usage: committee [OPTIONS] REPOSLUG...')
 
 
 def test_description():


### PR DESCRIPTION
In the `test_usage` test, there is a plural form of the repository slug argument. However, in the other tests, there is a singular form.